### PR TITLE
Improve the has_area_tags() function in the basic topic

### DIFF
--- a/themes/basic/init.lua
+++ b/themes/basic/init.lua
@@ -6,43 +6,118 @@
 
 local theme = {}
 
--- Helper function that looks at the tags and decides if this is possibly
--- an area.
+local function init_polygon_lookup()
+    -- Objects with any of the following keys will be treated as polygon
+    local polygon_keys = {
+        'abandoned:aeroway',
+        'abandoned:amenity',
+        'abandoned:building',
+        'abandoned:landuse',
+        'abandoned:power',
+        'aeroway',
+        'allotments',
+        'amenity',
+        'area:highway',
+        'building',
+        'building:part',
+        'club',
+        'craft',
+        'emergency',
+        'golf',
+        'harbour',
+        'healthcare',
+        'historic',
+        'landuse',
+        'leisure',
+        'man_made',
+        'military',
+        'natural',
+        'office',
+        'place',
+        'power',
+        'public_transport',
+        'shop',
+        'tourism',
+        'water',
+        'wetland'
+    }
+
+    -- Objects with these key/value combinations will be treated as linestring
+    local linestring_values = {
+        aeroway = {'taxiway', 'runway'},
+        emergency = {'designated', 'destination', 'no', 'official', 'yes'},
+        golf = {'cartpath', 'hole', 'path'},
+        historic = {'citywalls'},
+        leisure = {'track', 'slipway'},
+        man_made = {'breakwater', 'cutline', 'embankment', 'groyne', 'pipeline'},
+        natural = {'cliff', 'earth_bank', 'tree_row', 'ridge', 'arete'},
+        power = {'cable', 'line', 'minor_line'},
+        tourism = {'yes'}
+    }
+
+    -- Objects with these key/value combinations will be treated as polygon
+    local polygon_values = {
+        aerialway = {'station'},
+        boundary = {'aboriginal_lands', 'national_park', 'protected_area'},
+        highway = {'services', 'rest_area'},
+        junction = {'yes'},
+        railway = {'station'},
+        waterway = {'dock', 'boatyard', 'fuel', 'riverbank'}
+    }
+
+    local lookup_table = {}
+
+    local function init_values(list, set_to)
+        for key, values in pairs(list) do
+            for _, value in ipairs(values) do
+                if lookup_table[key] == nil then
+                    lookup_table[key] = {}
+                end
+                lookup_table[key][value] = set_to
+            end
+        end
+    end
+
+    init_values(linestring_values, false)
+    init_values(polygon_values, true)
+
+    for _, key in ipairs(polygon_keys) do
+        if lookup_table[key] == nil then
+            lookup_table[key] = true
+        else
+            lookup_table[key][''] = true
+        end
+    end
+
+    return lookup_table
+end
+
+local is_polygon = init_polygon_lookup()
+
+-- Helper function that looks at the tags and decides if this is an area.
 function theme.has_area_tags(tags)
-    if tags.area == 'yes' then
+    local area = tags.area
+    if area == 'yes' then
         return true
     end
-    if tags.area == 'no' then
+    if area == 'no' then
         return false
     end
 
-    return tags.aeroway
-        or tags.amenity
-        or tags.building
-        or tags.harbour
-        or tags.historic
-        or tags.landuse
-        or tags.leisure
-        or tags.man_made
-        or tags.military
-        or tags.natural
-        or tags.office
-        or tags.place
-        or tags.power
-        or tags.public_transport
-        or tags.shop
-        or tags.sport
-        or tags.tourism
-        or tags.water
-        or tags.waterway
-        or tags.wetland
-        or tags['abandoned:aeroway']
-        or tags['abandoned:amenity']
-        or tags['abandoned:building']
-        or tags['abandoned:landuse']
-        or tags['abandoned:power']
-        or tags['area:highway']
-        or tags['building:part']
+    for k, v in pairs(tags) do
+        local item = is_polygon[k]
+        if item == true then
+            return true
+        end
+        if item ~= nil then
+            if item[v] ~= nil then
+                return item[v]
+            end
+            if item[''] ~= nil then
+                return item[v]
+            end
+        end
+    end
 end
 
 return theme


### PR DESCRIPTION
It now also checks for some key-value combinations. Configuration is still relatively simple using lists of key and values. The config is initialized once into a hash table to make lookup (which are needed for each tag of each object) cheap.