### PR TITLE
Establish a way to define theme helper functions with unit tests

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -1,6 +1,29 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
+
+echo
+echo "=> Running themepark tests..."
+echo
 
 for test in tests/test-*.lua; do
+    echo "$test..."
     lua "$test"
+done
+
+echo
+echo "=> Running theme tests..."
+echo
+
+for themedir in themes/*; do
+    theme=${themedir#themes/}
+    if [[ -e "themes/$theme/tests" ]]; then
+        echo "$theme:"
+        (cd "themes/$theme/tests";
+        for atest in *; do
+            echo "* $atest..."
+            lua "$atest"
+        done)
+    fi
 done
 

--- a/themes/shortbread_v1/helper.lua
+++ b/themes/shortbread_v1/helper.lua
@@ -1,0 +1,22 @@
+-- ---------------------------------------------------------------------------
+--
+-- Theme: shortbread_v1
+--
+-- helper.lua
+--
+-- ---------------------------------------------------------------------------
+--
+-- Only use code in here that is independent of osm2pgsql, the themepark
+-- framework and the theme, so that it can be unit-tested!
+--
+-- ---------------------------------------------------------------------------
+
+local helper = {}
+
+function helper.is_yes_true_or_one(value)
+    return value == 'yes' or value == 'true' or value == '1'
+end
+
+return helper
+
+-- ---------------------------------------------------------------------------

--- a/themes/shortbread_v1/tests/test-helper.lua
+++ b/themes/shortbread_v1/tests/test-helper.lua
@@ -1,0 +1,32 @@
+-- ---------------------------------------------------------------------------
+--
+-- Theme: shortbread_v1
+--
+-- test-helper.lua
+--
+-- ---------------------------------------------------------------------------
+
+require 'busted.runner'()
+
+local helper = dofile('../helper.lua')
+
+describe('test is_yes_true_or_one', function()
+
+    it('should return true for yes, true, and 1', function()
+        assert.is_true(helper.is_yes_true_or_one('yes'))
+        assert.is_true(helper.is_yes_true_or_one('true'))
+        assert.is_true(helper.is_yes_true_or_one('1'))
+    end)
+
+    it('should return false for anything else', function()
+        assert.is_false(helper.is_yes_true_or_one())
+        assert.is_false(helper.is_yes_true_or_one(nil))
+        assert.is_false(helper.is_yes_true_or_one('no'))
+        assert.is_false(helper.is_yes_true_or_one('false'))
+        assert.is_false(helper.is_yes_true_or_one('0'))
+        assert.is_false(helper.is_yes_true_or_one('abc'))
+    end)
+
+end)
+
+-- ---------------------------------------------------------------------------

--- a/themes/shortbread_v1/topics/streets.lua
+++ b/themes/shortbread_v1/topics/streets.lua
@@ -223,10 +223,6 @@ local aeroway_lookup = {
     taxiway = 13,
 }
 
-local as_bool = function(value)
-    return value == 'yes' or value == 'true' or value == '1'
-end
-
 local set_ref_attributes = function(a, t)
     if not t.ref then
         return
@@ -285,8 +281,8 @@ local process_as_area = function(object, data)
 
     a.surface = t.surface
 
-    a.tunnel = as_bool(t.tunnel) or t.tunnel == 'building_passage' or t.covered == 'yes'
-    a.bridge = as_bool(t.bridge)
+    a.tunnel = theme.helper.is_yes_true_or_one(t.tunnel) or t.tunnel == 'building_passage' or t.covered == 'yes'
+    a.bridge = theme.helper.is_yes_true_or_one(t.bridge)
 
     a.geom = object:as_polygon():transform(3857)
     local has_name = themepark.themes.core.add_name(a, object)
@@ -372,8 +368,8 @@ themepark:add_proc('way', function(object, data)
         return
     end
 
-    a.tunnel = as_bool(t.tunnel) or t.tunnel == 'building_passage' or t.covered == 'yes'
-    a.bridge = as_bool(t.bridge)
+    a.tunnel = theme.helper.is_yes_true_or_one(t.tunnel) or t.tunnel == 'building_passage' or t.covered == 'yes'
+    a.bridge = theme.helper.is_yes_true_or_one(t.bridge)
 
     set_ref_attributes(a, t)
 


### PR DESCRIPTION
And use it in shortbread theme.

Not sure this is the right approach. Maybe load *all* files in the themes dir, not only `init.lua`  and `helper.lua` ?