### PR TITLE
Change file:reads to be *a instead of a*

### DIFF
--- a/lua/themepark.lua
+++ b/lua/themepark.lua
@@ -186,7 +186,7 @@ function themepark:init_theme(theme)
         end
         local file = io.open(theme_file)
         if file then
-            local script = file:read('a*')
+            local script = file:read('*a')
             file:close()
 
             local func, msg = load(script, theme_file, 't')
@@ -243,7 +243,7 @@ function themepark:add_topic(topic, options)
         error("No topic '" .. topic .. "' in theme '" .. theme_name .. "'")
     end
 
-    local script = file:read('a*')
+    local script = file:read('*a')
     file:close()
 
     local func, msg = load(script, filename, 't')


### PR DESCRIPTION
This resolved an issue I had setting up tilekiln.  I'm not a lua expert, but GPT claimed this was incorrect and changing it to match what it told me fixed my issue:

```
❯ osm2pgsql --output flex --style shortbread.lua -d spirit ~/osm/north-america-latest.osm.pbf
2025-02-24 18:22:39  osm2pgsql version 2.0.1
2025-02-24 18:22:39  Database version: 17.2
2025-02-24 18:22:39  PostGIS version: 3.5
2025-02-24 18:22:39  ERROR: Error loading lua config: /home/apenney/git/osm2pgsql-themepark/lua/themepark.lua:246: bad argument #1 to 'read' (invalid option).
```

After the change:

```
❯ osm2pgsql --output flex --style shortbread.lua -d spirit ~/osm/north-america-latest.osm.pbf
2025-02-24 18:24:37  osm2pgsql version 2.0.1
2025-02-24 18:24:37  Database version: 17.2
2025-02-24 18:24:37  PostGIS version: 3.5
2025-02-24 18:24:37  Initializing properties table '"public"."osm2pgsql_properties"'.
2025-02-24 18:24:37  Storing properties to table '"public"."osm2pgsql_properties"'.
Processing: Node(220820k 2083.2k/s) Way(0k 0.00k/s) Relation(0 0.0/s)
````