### PR TITLE
Fix typo

### DIFF
--- a/lua/themepark.lua
+++ b/lua/themepark.lua
@@ -472,7 +472,7 @@ end
 function themepark:plugin(name)
     self:init_layer_groups()
     local ts = require('themepark/plugins/' .. name, self)
-    ts.self = self
+    ts.themepark = self
     return ts
 end
 


### PR DESCRIPTION
Fix typo from commit f5869d0 which results in bbox config functionality being broken.